### PR TITLE
Selenium Web Driver の設定を変更してテストを動くようにする

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,15 +1,29 @@
-Capybara.register_driver :chrome_headless do |app|
-  options = ::Selenium::WebDriver::Chrome::Options.new
+# Capybara.register_driver :chrome_headless do |app|
+#   options = ::Selenium::WebDriver::Chrome::Options.new
 
-  options.add_argument('--headless')
-  options.add_argument('--no-sandbox')
-  options.add_argument('--disable-dev-shm-usage')
-  options.add_argument('--window-size=1400,1400')
+#   options.add_argument('--headless')
+#   options.add_argument('--no-sandbox')
+#   options.add_argument('--disable-dev-shm-usage')
+#   options.add_argument('--window-size=1400,1400')
 
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+#   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+# end
+
+Capybara.register_driver :selenium_container do |app|
+  url = ENV["SELENIUM_DRIVER_URL"]
+  caps = ::Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: [
+      'headless',
+      'no-sandbox',
+      'disable-gpu',
+      'window-size=1400,1400'
+    ],
+    w3c: false}
+  )
+  Capybara::Selenium::Driver.new(app, browser: :remote, url: url, desired_capabilities: caps)
 end
 
-Capybara.javascript_driver = :chrome_headless
+# Capybara.javascript_driver = :chrome_headless
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do
@@ -17,14 +31,20 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system, js: true) do
-    if ENV["SELENIUM_DRIVER_URL"].present?
-      driven_by :selenium, using: :chrome, options: {
-        browser: :remote,
-        url: ENV.fetch("SELENIUM_DRIVER_URL"),
-        desired_capabilities: :chrome
-      }
-    else
-      driven_by :selenium_chrome_headless
-    end
+    driven_by :selenium_container
+    
+    Capybara.server_host = IPSocket.getaddress('app')
+    Capybara.server_port = 3002
+    Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
+    
+    # if ENV["SELENIUM_DRIVER_URL"].present?
+    #   driven_by :selenium, using: :chrome, options: {
+    #     browser: :remote,
+    #     url: ENV.fetch("SELENIUM_DRIVER_URL"),
+    #     desired_capabilities: :chrome
+    #   }
+    # else
+    #   driven_by :selenium_chrome_headless
+    # end
   end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -134,15 +134,15 @@ RSpec.describe "Users", type: :system do
       expect(user.reload.email).not_to eq ""
     end
 
-    #  context "アカウント削除処理", js: true do
-    #  it "正しく削除できること" do
-    #    click_link "アカウントを削除する"
-    #    page.accept_confirm do
-    #      click_on :delete_button
-    #    end
-    #    expect(page).to have_content "自分のアカウントを削除しました"
-    #  end
-    #  end
+    context "アカウント削除処理", js: true do
+      it "正しく削除できること" do
+        click_link "アカウントを削除する"
+        page.accept_confirm do
+          click_on :delete_button
+        end
+        expect(page).to have_content "自分のアカウントを削除しました"
+      end
+    end
   end
 
   describe "プロフィールページ" do


### PR DESCRIPTION
`capybara.rb` の設定を変更して、Selenium Web Driver を利用したテストが動くようにしました。
既存のコードは消さずにコメントアウトしました。

テストを実行するために `spec/system/users_spec.rb` の `js: true` のテストを1つだけコメントを外しています。

```
bin/rspec spec/system/users_spec.rb:137
```

でテストを実行すると動いていると思います。
テスト自体はFailedになりますが、Chromeを経由して実行されているので、
テストを修正すればPassすると思います。
