### PR TITLE
docker volume の public-data の利用をやめる

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     command: bundle exec puma -C config/puma.rb
     volumes:
       - .:/webapp
-      - public-data:/webapp/public
       - tmp-data:/webapp/tmp
       - log-data:/webapp/log
     depends_on:
@@ -25,7 +24,7 @@ services:
     build:
       context: containers/nginx
     volumes:
-      - public-data:/webapp/public
+      - ./public:/webapp/public
       - tmp-data:/webapp/tmp
     ports:
       - 80:80
@@ -36,7 +35,6 @@ services:
     logging:
       driver: none
 volumes:
-  public-data:
   tmp-data:
   log-data:
   db-data:


### PR DESCRIPTION
画像は `public/` ディレクトリ以下に設置されていますが、そのディレクトリは docker volume の `public-data` にバインドされています。
https://github.com/taiki-mtb/portfolio/blob/df7084aad99871104dee21e6676738996a611f79/docker-compose.yml#L28
そのため、ローカルで `public/images` に新しい画像を追加しても public-data に反映されないので404になってしまいます。


ローカルディレクトリを直接バインドする設定に変更しました。
